### PR TITLE
Bugfix on version number updates

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -286,7 +286,10 @@ if version_number_source.nil? and version_strategy == 'keep'
   puts "No version number source specified and strategy is keep. Skipping version number update"
 else
   current_version_number = get_version_number(params, version_number_source)
-  next_version_number = calculate_version_number(current_version_number, version_strategy, omit_zero, version_offset)
+  if version_strategy == 'keep'
+    next_version_number = current_version_number
+  else
+    next_version_number = calculate_version_number(current_version_number, version_strategy, omit_zero, version_offset)
   puts "Next version: #{next_version_number}  Reason -> Source: #{version_number_source} Strategy: #{version_strategy} Omit zero: #{omit_zero} Offset: #{version_offset}"
   increment_key(params, 'CFBundleShortVersionString', next_version_number,'MARKETING_VERSION')
 end

--- a/main.rb
+++ b/main.rb
@@ -282,8 +282,8 @@ else
   increment_key(params, 'CFBundleVersion', next_build_number,'CURRENT_PROJECT_VERSION')
 end 
 
-if version_number_source.nil? or version_strategy == 'keep'
-  puts "No version number source specified or strategy is keep. Skipping version number update"
+if version_number_source.nil? and version_strategy == 'keep'
+  puts "No version number source specified and strategy is keep. Skipping version number update"
 else
   current_version_number = get_version_number(params, version_number_source)
   next_version_number = calculate_version_number(current_version_number, version_strategy, omit_zero, version_offset)

--- a/main.rb
+++ b/main.rb
@@ -282,14 +282,15 @@ else
   increment_key(params, 'CFBundleVersion', next_build_number,'CURRENT_PROJECT_VERSION')
 end 
 
-if version_number_source.nil? and version_strategy == 'keep'
-  puts "No version number source specified and strategy is keep. Skipping version number update"
+if version_number_source.nil?
+  puts "No version number source specified. Skipping version number update"
 else
   current_version_number = get_version_number(params, version_number_source)
   if version_strategy == 'keep'
     next_version_number = current_version_number
   else
     next_version_number = calculate_version_number(current_version_number, version_strategy, omit_zero, version_offset)
+  end
   puts "Next version: #{next_version_number}  Reason -> Source: #{version_number_source} Strategy: #{version_strategy} Omit zero: #{omit_zero} Offset: #{version_offset}"
   increment_key(params, 'CFBundleShortVersionString', next_version_number,'MARKETING_VERSION')
 end


### PR DESCRIPTION
Changed logical operator used to determine if we need to skip the version number update.

Should fix https://github.com/appcircleio/appcircle-ios-build-version-increment/issues/5